### PR TITLE
flake8とmypyの設定の見直し

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,13 @@
 [flake8]
 # e203: black treats : as a binary operator
 # e231: black doesn't put a space after ,
-# e501: black may exceed the line-length to follow other style rules
 # w503 or w504: either one needs to be disabled to select w error codes
-ignore = E203,E231,E501,W503
+ignore = E203,E231,W503
 select = B,B950,C,E,F,W
 per-file-ignores =
     # imported but unused
     __init__.py: F401
+max-line-length = 120
 
 [mypy]
 check_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ per-file-ignores =
 max-line-length = 120
 
 [mypy]
-python_version = 3.7
+python_version = 3.8
 strict = True
 warn_unreachable = True
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,5 +13,6 @@ max-line-length = 120
 python_version = 3.8
 strict = True
 warn_unreachable = True
+# Ignore errors when importing libraries that don't have a stub file (*.pyi) with type hints
 ignore_missing_imports = True
 show_error_codes = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,5 @@ warn_unreachable = True
 # Ignore errors when importing libraries that don't have a stub file (*.pyi) with type hints
 ignore_missing_imports = True
 show_error_codes = True
+# If `implicit_reexport = False`, you must explicitly add to `__all__` to re-export.
+implicit_reexport = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,25 +10,8 @@ per-file-ignores =
 max-line-length = 120
 
 [mypy]
-check_untyped_defs = True
-disallow_any_decorated = False
-disallow_any_generics = True
-disallow_any_unimported = False
-disallow_incomplete_defs = True
-disallow_subclassing_any = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = False
-disallow_untyped_defs = True
-ignore_errors = False
-ignore_missing_imports = True
-no_implicit_optional = True
 python_version = 3.7
-show_error_codes = True
-strict_equality = True
-strict_optional = True
-warn_redundant_casts = True
-warn_return_any = True
+strict = True
 warn_unreachable = True
-warn_unused_configs = True
-warn_unused_ignores = True
-
+ignore_missing_imports = True
+show_error_codes = True


### PR DESCRIPTION
## 概要

`setup.cfg` に記述していたflake8、 mypyの設定を見直しました。

pysenを使ってオプションを管理していた時の名残があり、少し気になるところがありました。

## flake8

E501を無視するのではなくて、最大行数を指定した方が良さそうです。
Blackのデフォルトは88文字のようですが、120文字とする設定が広く利用されていそうでした。

- https://www.flake8rules.com/rules/E501.html

## mypy

pysen を使っていた時は、`mypy_preset = "strict"`としていました。
この時、有効になるオプションが現在の `setup.cfg` に羅列されています。

これらは、mypyでも `strict = True`として設定することで利用できるので、オプションを羅列する必要は無さそうです。
管理の面からも、整理しようと思いました。

### デフォルトで設定されていたもの

mypy のデフォルトで設定されているものは、これらでした。
冗長なので、記述する必要はないと思います。

```
disallow_any_decorated = False
disallow_any_unimported = False
strict_optional = True
ignore_errors = False
```

### `strict = True` で設定されるもの

`mypy --help` より、`--strict` オプションをつけた場合(`setup.cfg`内で`strict = True`とした場合と同様)に、有効になるものを確認しました。
これらは個別に設定する必要は無さそうです。

```
--check-untyped-defs, 
--disallow-any-generics,
--disallow-incomplete-defs, 
--disallow-subclassing-any,
--disallow-untyped-calls, 
--disallow-untyped-decorators, 
--disallow-untyped-defs, 
--no-implicit-optional,
--no-implicit-reexport,
--strict-equality,
--warn-redundant-casts, 
--warn-return-any, 
--warn-unused-configs,
--warn-unused-ignores,
```

### 個別に設定されていたもの

#### `warn_unreachable = True`

不達コードを検出できることは有益なので、Trueにしておきます。

#### `ignore_missing_imports = True`

ライブラリが型情報を持っていない時に無視するオプションです。
特にこの問題で悩まされがちなので、グローバルに設定しておく運用が良いかもしれないと思っています。

#### `show_error_codes = True`

エラーコードは、コードを修正する場合に有益な情報になりそうなので、Trueにしておきます。

### 新しく有効になるオプション

#### `--no-implicit-reexport`

`__init__.py`などで、明示的にエクスポートするために`__all__`を使ったコードに修正する必要が出てきます。

https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport

エクスポートすることを明示的に書くことで、プログラマの意図を表現出来て良さそうです。しかし、慣れないオプションなので無効にしておくほうが混乱は少ないかもしれないなと思っています。