### PR TITLE
Use ~/.local/share/pypoetry as POETRY_HOME

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,4 +3,7 @@ ARG VARIANT
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
 # Requires $POETRY_HOME to install the location; poetry is installed under /root by default.
-RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/home/vscode/.local python3 -
+ENV POETRY_HOME=/home/vscode/.local/share/pypoetry
+ENV PATH="${POETRY_HOME}/bin:${PATH}"
+
+RUN curl -sSL https://install.python-poetry.org | python3 -


### PR DESCRIPTION
## 概要

- Close #40 

poetryは、Linux/Unixではデフォルトで `~/.local/share/pypoetry` を `POETRY_HOME` としてインストールするようです。
このデフォルトの挙動と合うように、このリポジトリでは`POETRY_HOME`を`/home/vscode/.local`から`/home/vscode/.local/share/pypoetry`に変更しました。